### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,12 +77,12 @@ jobs:
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@v4.0.0
       - # https://github.com/docker/setup-buildx-action/issues/57#issuecomment-1059657292
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4.0.0
         with:
           buildkitd-config: .github/buildkitd.toml
           driver-opts: |
@@ -90,25 +90,25 @@ jobs:
             env.https_proxy=${{ env.http_proxy }}
             "env.no_proxy='${{ env.no_proxy}}'"
       - name: Login to DockerHub
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.1.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Login to Quay.io
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.0.0
         with:
           images: |
             name=snowdreamtech/ubuntu,enable=true
@@ -132,7 +132,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           build-args: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v7.1.0](https://github.com/docker/build-push-action/releases/tag/v7.1.0)** on 2026-04-10T09:59:25Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v4.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0)** on 2026-03-04T07:58:53Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v4.1.0](https://github.com/docker/login-action/releases/tag/v4.1.0)** on 2026-04-02T17:24:23Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v6.0.0](https://github.com/docker/metadata-action/releases/tag/v6.0.0)** on 2026-03-05T17:57:34Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v4.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0)** on 2026-03-05T07:58:20Z
